### PR TITLE
Added parameter functionality to pass values between pages

### DIFF
--- a/app/Http/Livewire/Contact/Edit.php
+++ b/app/Http/Livewire/Contact/Edit.php
@@ -12,7 +12,7 @@ class Edit extends Component
 
     public bool $embedded =  false;
 
-    public $parentId;
+    public $params;
     public $name;
     public $phone;
     public $email;
@@ -29,10 +29,11 @@ class Edit extends Component
     }
 
     public function save($repeat = false){
-        $parentId = $this->parentId;
+        $params = $this->params;
+
         $this->validate();
         $contact = Contact::create([
-            'policy_id' => $this->parentId,
+            'policy_id' => $params['parentId'],
             'name' => $this->name,
             'phone' => $this->phone,
             'email' => $this->email
@@ -44,7 +45,7 @@ class Edit extends Component
         else {
             $this->reset();
             $this->embedded = true;
-            $this->parentId = $parentId;
+            $this->params = $params;
         }
     }
 }

--- a/app/Http/Livewire/Contact/Index.php
+++ b/app/Http/Livewire/Contact/Index.php
@@ -7,15 +7,14 @@ use Livewire\Component;
 
 class Index extends Component
 {
-
-    public $parentId;
+    public $params;
     public $contacts = [];
     public bool $embedded = false;
 
     public function render()
     {
-        if($this->parentId)
-            $this->contacts = Contact::where('policy_id',$this->parentId)->get();
+        if($this->params)
+            $this->contacts = Contact::where('policy_id', $this->params['parentId'])->get();
         return view('livewire.contact.index');
     }
 }

--- a/app/Http/Livewire/Coverage/Edit.php
+++ b/app/Http/Livewire/Coverage/Edit.php
@@ -11,7 +11,7 @@ class Edit extends Component
 
     public bool $embedded =  false;
 
-    public $parentId;
+    public $params;
 
     public $name;
     public $limit;
@@ -34,11 +34,11 @@ class Edit extends Component
 
     public function save($repeat = false){
         // may no longer need repeat, since we are changing default flow.
-        $parentId = $this->parentId;
+        $params = $this->params;
         $this->validate();
 
         $coverage = Coverage::create([
-            'policy_id' => $this->parentId,
+            'policy_id' => $this->params['parentId'],
             'name' => $this->name,
             'limit' => $this->limit,
             'deductible_amount' => $this->deductible_amount,
@@ -52,7 +52,7 @@ class Edit extends Component
         else {
             $this->reset();
             $this->embedded = true;
-            $this->parentId = $parentId;
+            $this->params = $params;
         }
     }
 }

--- a/app/Http/Livewire/Coverage/Index.php
+++ b/app/Http/Livewire/Coverage/Index.php
@@ -7,15 +7,14 @@ use Livewire\Component;
 
 class Index extends Component
 {
-
-    public $parentId;
+    public $params;
     public $coverages =[];
     public bool $embedded = false;
 
     public function render()
     {
-        if($this->parentId)
-            $this->coverages = Coverage::where('policy_id',$this->parentId)->get();
+        if($this->params)
+            $this->coverages = Coverage::where('policy_id',$this->params['parentId'])->get();
         return view('livewire.coverage.index');
     }
 }

--- a/app/Http/Livewire/Insurance/View.php
+++ b/app/Http/Livewire/Insurance/View.php
@@ -7,17 +7,16 @@ use Livewire\Component;
 
 class View extends Component
 {
-
     public Policy $policy;
 
-    public $parentId;
+    public $params;
 
     public bool $embedded = false;
 
     public function render()
     {
-        if($this->embedded && $this->parentId){
-            $this->policy = Policy::find($this->parentId);
+        if($this->embedded && $this->params){
+            $this->policy = Policy::find($this->params['parentId']);
         }
         return view('livewire.insurance.view');
     }

--- a/app/Http/Livewire/Policy/Edit.php
+++ b/app/Http/Livewire/Policy/Edit.php
@@ -40,6 +40,6 @@ class Edit extends Component
             'annual_premium' => $this->annual_premium,
             'payment_schedule'=> $this->payment_schedule
         ]);
-        $this->emitTo('wizard.base', 'next', $policy->id);
+        $this->emitTo('wizard.base', 'next', ['parentId' => $policy->id]);
     }
 }

--- a/app/Http/Livewire/Policy/View.php
+++ b/app/Http/Livewire/Policy/View.php
@@ -7,15 +7,14 @@ use Livewire\Component;
 
 class View extends Component
 {
-
-    public $parentId;
+    public $params;
     public $policy;
     public bool $embedded = false;
 
     public function render()
     {
-        if($this->parentId)
-            $this->policy = Policy::find($this->parentId);
+        if($this->params)
+            $this->policy = Policy::find($this->params['parentId']);
         return view('livewire.policy.view');
     }
 }

--- a/app/Http/Livewire/Wizard/Base.php
+++ b/app/Http/Livewire/Wizard/Base.php
@@ -10,7 +10,7 @@ class Base extends Component
 
     public array $screen;
     public int $currentIndex = 0;
-    public $parentId;
+    public $params;
 
     // componet will pass back next or repeat
     public $screens = [
@@ -207,9 +207,9 @@ class Base extends Component
        return view('livewire.wizard.base');
     }
 
-    public function next($id = null){
-        if($id){
-            $this->parentId = $id;
+    public function next($params = null){
+        if($params){
+            $this->params = $params;
         }
 
         error_log("next wizard screen");

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["framework", "laravel"],
     "license": "MIT",
     "require": {
-        "php": "^8.1",
+        "php": "^7.4|^8.1",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
         "laravel/framework": "^8.75",

--- a/resources/views/livewire/insurance/view.blade.php
+++ b/resources/views/livewire/insurance/view.blade.php
@@ -5,8 +5,8 @@
     @else
         <div class="pl-2 space-y-3">
     @endif
-        <livewire:policy.view  :parentId="$policy->id" :embedded="$embedded"/>
-        <livewire:coverage.index :parentId="$policy->id" :embedded="$embedded"/>
-        <livewire:contact.index  :parentId="$policy->id" :embedded="$embedded"/>
+        <livewire:policy.view  :params="['parentId' => $policy->id]" :embedded="$embedded"/>
+        <livewire:coverage.index :params="['parentId' => $policy->id]" :embedded="$embedded"/>
+        <livewire:contact.index  :params="['parentId' => $policy->id]" :embedded="$embedded"/>
     </div>
 </div>

--- a/resources/views/livewire/wizard/base.blade.php
+++ b/resources/views/livewire/wizard/base.blade.php
@@ -3,7 +3,7 @@
     <div class="h-80 w-96 border border-gray-300 shadow-sm shadow-zinc-500 p-2 overflow-y-auto overflow-x-clip">
         <livewire:is :component="$screens[$currentIndex]['component']"
                      :embedded="true"
-                     :parentId="$parentId"
+                     :params="$params"
                      wire:key/>
     </div>
 


### PR DESCRIPTION
Useful when you want to pass parameters to the next page of the wizard, such as a parent object id and class.